### PR TITLE
feat: create GitHub issue on pipeline failure

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  issues: write
 
 concurrency:
   group: ci-main
@@ -145,3 +146,27 @@ jobs:
           body_path: release_notes.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  notify-failure:
+    if: ${{ failure() }}
+    needs: [ci-release]
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Create issue on pipeline failure
+        run: |
+          gh issue create \
+            --repo "${{ github.repository }}" \
+            --title "Pipeline failure: ${{ github.workflow }} (#${{ github.run_number }})" \
+            --label "ci" \
+            --body "$(cat <<EOF
+          **Workflow:** \`${{ github.workflow }}\`
+          **Run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Branch:** \`${{ github.ref_name }}\`
+          **Commit:** \`${{ github.sha }}\`
+          **Triggered by:** ${{ github.actor }}
+          EOF
+          )"
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary

- Adds a `notify-failure` job to the CI workflow that automatically creates a GitHub issue when the pipeline fails
- Adds `issues: write` permission at both workflow and job level to allow issue creation
- The created issue includes workflow name, run link, branch, commit, and actor details with a `ci` label

## Test plan

- [ ] Verify the workflow YAML is valid by checking the Actions tab after merge
- [ ] Optionally trigger a failure scenario to confirm issue creation works